### PR TITLE
Remove library link of Qt6::WinMain for Windows

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -752,9 +752,6 @@ target_link_libraries(tomvizlib
   PRIVATE
     Qt6::Core5Compat
     Python3::Python)
-if(WIN32)
-  target_link_libraries(tomvizlib PUBLIC Qt6::WinMain)
-endif()
 
 if(APPLE)
   set_target_properties(tomviz


### PR DESCRIPTION
This link is no longer needed, and causes an error on Windows.

This isn't actually needed for the HXN workflow.