### PR TITLE
Sort ptycho files by angle

### DIFF
--- a/tomviz/python/tomviz/ptycho/ptycho.py
+++ b/tomviz/python/tomviz/ptycho/ptycho.py
@@ -195,6 +195,13 @@ def load_stack_ptycho(version_list: list[str],
                       output_dir: PathLike,
                       rotate_datasets: bool = True) -> PathLike:
 
+    # Everything is currently sorted by SID. Usually, that means
+    # everything is also sorted by angle, but that is not always
+    # the case. Ensure everything is re-sorted by angle.
+    angle_list, sid_list, version_list = (
+        zip(*sorted(zip(angle_list, sid_list, version_list)))
+    )
+
     filespty_obj = []
     filespty_prb = []
     currentsidlist = []


### PR DESCRIPTION
The displayed table of ptycho files is sorted by SID, which is good.

Usually, if the files are sorted by SID, that means they are also sorted by angle. However, that is not always the case.

Sort the ptycho files by angle when stacking, as they need to be sorted by angle in the final image stack.

@aaron4444 