### PR TITLE
Restore rescaling opacity to B&C editor

### DIFF
--- a/tomviz/BrightnessContrastWidget.cxx
+++ b/tomviz/BrightnessContrastWidget.cxx
@@ -318,6 +318,7 @@ public:
   void rescaleNodes(double newMin, double newMax)
   {
     tomviz::rescaleNodes(m_uncroppedLut, newMin, newMax);
+    tomviz::rescaleNodes(m_uncroppedOpacity, newMin, newMax);
     pushChanges();
     updateGui();
   }


### PR DESCRIPTION
This was originally removed in d0314164, since I originally thought it did not make sense for a B&C editor to also modify opacity.

Users are actually expecting and relying on this, however, and adjusting the opacity to hide the voxels below the minimum is necessary for thresholding them out. Thus, we are restoring this behavior.